### PR TITLE
Fix mobile double-tap zoom issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>Counter</title>
   </head>
   <body>

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -4,3 +4,13 @@
   margin: 0;
   padding: 0;
 }
+
+/* Prevent double-tap zoom on mobile */
+button, input, select, textarea {
+  touch-action: manipulation;
+}
+
+/* Additional prevention for any interactive elements */
+[onclick], [role="button"] {
+  touch-action: manipulation;
+}


### PR DESCRIPTION
## Summary
- Fixed mobile double-tap zoom issue that was causing unwanted expansion
- Added `user-scalable=no` to viewport meta tag to prevent zoom
- Added `touch-action: manipulation` CSS rules for interactive elements

## Test plan
- [ ] Test on mobile devices to ensure double-tap no longer causes zoom
- [ ] Verify all buttons and interactive elements work correctly
- [ ] Confirm accessibility is maintained

🤖 Generated with [Claude Code](https://claude.ai/code)