### PR TITLE
Fix busy time duration from 3s to 1s

### DIFF
--- a/src/features/counter/infra/api.a.ts
+++ b/src/features/counter/infra/api.a.ts
@@ -7,7 +7,7 @@ export const getCountA: GetCount = (): Promise<Result<Count>> => {
   return new Promise((resolve, _reject) => {
     setTimeout(() => {
       resolve(ok(_count))
-    }, 3_000)
+    }, 1_000)
   })
 }
 
@@ -17,6 +17,6 @@ export const postCountA: PostCount = (count: Count): Promise<Result<Count>> => {
   return new Promise((resolve, _reject) => {
     setTimeout(() => {
       resolve(ok(count))
-    }, 3_000)
+    }, 1_000)
   })
 }

--- a/src/features/counter/infra/api.b.ts
+++ b/src/features/counter/infra/api.b.ts
@@ -7,7 +7,7 @@ export const getCountB: GetCount = (): Promise<Result<Count>> => {
   return new Promise((resolve, _reject) => {
     setTimeout(() => {
       resolve(ok(_count))
-    }, 3_000)
+    }, 1_000)
   })
 }
 
@@ -17,6 +17,6 @@ export const postCountB: PostCount = (count: Count): Promise<Result<Count>> => {
   return new Promise((resolve, _reject) => {
     setTimeout(() => {
       resolve(ok(count))
-    }, 3_000)
+    }, 1_000)
   })
 }


### PR DESCRIPTION
## Summary
- Reduces API delay timeout from 3000ms to 1000ms in both api.a.ts and api.b.ts
- Improves user experience with faster save/load operations
- Addresses the issue where busy state duration was too long

## Changes
- Modified `src/features/counter/infra/api.a.ts` - Changed setTimeout delays from 3_000ms to 1_000ms
- Modified `src/features/counter/infra/api.b.ts` - Changed setTimeout delays from 3_000ms to 1_000ms

## Test plan
- [ ] Verify counter save operation completes in ~1 second
- [ ] Verify counter load operation completes in ~1 second
- [ ] Confirm busy indicator displays for appropriate duration
- [ ] Test both API implementations work correctly

Fixes #2

🤖 Generated with [Claude Code](https://claude.ai/code)