### PR TITLE
Add LocalStorage support to counter API

### DIFF
--- a/src/features/counter/infra/api.b.ts
+++ b/src/features/counter/infra/api.b.ts
@@ -2,17 +2,28 @@ import { type Result, ok } from "../../../shared/Result"
 import type { Count } from "../domain"
 import type { GetCount, PostCount } from "../domain/env"
 
-let _count: Count = 0
+const STORAGE_KEY = 'fp-vm-counter'
+
+const getCountFromStorage = (): Count => {
+  const stored = localStorage.getItem(STORAGE_KEY)
+  return stored ? parseInt(stored, 10) : 0
+}
+
+const saveCountToStorage = (count: Count): void => {
+  localStorage.setItem(STORAGE_KEY, count.toString())
+}
+
 export const getCountB: GetCount = (): Promise<Result<Count>> => {
   return new Promise((resolve, _reject) => {
     setTimeout(() => {
-      resolve(ok(_count))
+      const count = getCountFromStorage()
+      resolve(ok(count))
     }, 1_000)
   })
 }
 
 export const postCountB: PostCount = (count: Count): Promise<Result<Count>> => {
-  _count = count
+  saveCountToStorage(count)
 
   return new Promise((resolve, _reject) => {
     setTimeout(() => {


### PR DESCRIPTION
## Summary
- Implements LocalStorage persistence for counter state as requested in #3
- Replaces in-memory storage with browser LocalStorage in api.b.ts
- Counter state now persists across browser sessions

## Changes
- Added LocalStorage helper functions for get/set operations
- Updated `getCountB` to load count from LocalStorage
- Updated `postCountB` to save count to LocalStorage
- Uses 'fp-vm-counter' as the storage key

## Test plan
- [x] Build passes
- [x] All existing tests pass
- [x] LocalStorage functionality works in browser
- [x] Counter state persists across page refreshes

🤖 Generated with [Claude Code](https://claude.ai/code)